### PR TITLE
Fix README mermaid syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ classDiagram
     class BNO085 {
   +begin() + enableSensor() + update() + setCallback() + getLatest()
     }
-    class IBNO085Transport <|.. I2CTransport
-    class IBNO085Transport <|.. SPITransport
+    IBNO085Transport <|-- I2CTransport
+    IBNO085Transport <|-- SPITransport
     class SensorEvent
     BNO085 --> IBNO085Transport : uses
     BNO085 --> SensorEvent : "produces ➡️"
+```
 The BNO085 class shields your app from the gritty SH-2/SHTP details, while IBNO085Transport shields it from your hardware.
 
 ## Library Structure 🗂️


### PR DESCRIPTION
## Summary
- fix inheritance arrows in the class diagram

## Testing
- `grep -n '```' README.md`
