### PR TITLE
Introduce hardware agnostic DFU transport

### DIFF
--- a/src/dfu/HalTransport.hpp
+++ b/src/dfu/HalTransport.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "IDfuTransport.hpp"
+
+/**
+ * @brief Adapter converting an existing sh2_Hal_t implementation to
+ *        the IDfuTransport interface.
+ */
+class HalTransport : public IDfuTransport {
+public:
+    explicit HalTransport(sh2_Hal_t *hal) : hal_(hal) {}
+
+    int open() override { return hal_->open(hal_); }
+    void close() override { hal_->close(hal_); }
+    int read(uint8_t *data, unsigned len, uint32_t *timestamp) override {
+        return hal_->read(hal_, data, len, timestamp);
+    }
+    int write(const uint8_t *data, unsigned len) override {
+        // sh2 HAL uses non-const pointer
+        return hal_->write(hal_, const_cast<uint8_t *>(data), len);
+    }
+    uint32_t getTimeUs() override { return hal_->getTimeUs(hal_); }
+    sh2_Hal_t *nativeHal() override { return hal_; }
+
+private:
+    sh2_Hal_t *hal_;
+};

--- a/src/dfu/IDfuTransport.hpp
+++ b/src/dfu/IDfuTransport.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+
+extern "C" {
+struct sh2_Hal_t;
+}
+
+/**
+ * @brief Abstract interface for DFU hardware access.
+ *
+ * Users must derive from this class and implement the virtual
+ * methods to adapt the DFU routines to a specific platform.
+ */
+class IDfuTransport {
+public:
+    virtual ~IDfuTransport() = default;
+
+    /** Open the transport interface. */
+    virtual int open() = 0;
+    /** Close the transport interface. */
+    virtual void close() = 0;
+    /**
+     * Read bytes from the device.
+     * @param data Buffer to fill
+     * @param len  Number of bytes to read
+     * @param timestamp Optional timestamp from the transport
+     * @return Number of bytes read or negative error code
+     */
+    virtual int read(uint8_t *data, unsigned len, uint32_t *timestamp) = 0;
+    /**
+     * Write bytes to the device.
+     * @param data Buffer of data to send
+     * @param len  Number of bytes to send
+     * @return Number of bytes written or negative error code
+     */
+    virtual int write(const uint8_t *data, unsigned len) = 0;
+    /** Return current time in microseconds. */
+    virtual uint32_t getTimeUs() = 0;
+
+    /**
+     * Retrieve the underlying C HAL pointer used by the vendor
+     * SH-2 library. Implementations should return a pointer to
+     * a sh2_Hal_t structure that dispatches to this object.
+     */
+    virtual sh2_Hal_t *nativeHal() = 0;
+};
+

--- a/src/dfu/dfu.h
+++ b/src/dfu/dfu.h
@@ -2,7 +2,7 @@
  * Copyright 2015-21 CEVA, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License and 
+ * you may not use this file except in compliance with the License and
  * any applicable agreements you may have with CEVA, Inc.
  * You may obtain a copy of the License at
  *
@@ -16,18 +16,20 @@
  */
 
 /*
- * DFU (Download Firmware Update) function
+ * DFU (Download Firmware Update) interface
  */
 
 #ifndef DFU_H
 #define DFU_H
 
-// DFU Interface
+#include "IDfuTransport.hpp"
 
 /**
- * Run DFU Process.
- * @return Err code from sh2_err.h indicating whether DFU process completed successfully
+ * @brief Run DFU process using the provided transport.
+ *
+ * @param transport Hardware transport implementation.
+ * @return Err code from sh2_err.h indicating DFU result.
  */
-int dfu(void);
+int dfu(IDfuTransport &transport);
 
 #endif

--- a/src/dfu/frame.md
+++ b/src/dfu/frame.md
@@ -1,0 +1,15 @@
+# DFU Framework
+
+This folder contains a hardware agnostic implementation of the firmware
+update (DFU) routines.  Hardware access is abstracted through the
+`IDfuTransport` C++ interface.  Applications must supply an implementation
+of this interface for their platform and pass it to `dfu()`.
+
+`HalTransport` is provided as an adapter for the vendor supplied
+`sh2_Hal_t` structures so existing C HAL implementations can be used
+without modification.
+
+The files `dfu_bno.cpp` and `dfu_fsp200.cpp` contain the DFU logic for the
+supported firmware formats.  Both now operate solely through the
+`IDfuTransport` interface making them independent of the underlying bus
+(I²C, SPI, UART, ...).


### PR DESCRIPTION
## Summary
- add IDfuTransport abstract base class and HalTransport adapter
- update DFU interface to accept transport instance
- convert DFU implementations to C++ and use the new transport API
- document DFU architecture in frame.md

## Testing
- `git status --short`