### PR TITLE
Expose interface select helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# HF - BNO08x
+#HF - BNO08x
 Hardware Agnostic BNO08x library - as used in the HardFOC-V1 controller
 
-# BNO085 C++ Sensor Library 🚀
+#BNO085 C++ Sensor Library 🚀
 
 > **Full-stack, hardware-agnostic, zero-thread driver for Hillcrest / CEVA BNO08x**  
 
@@ -40,6 +40,7 @@ Hardware Agnostic BNO08x library - as used in the HardFOC-V1 controller
 | 🔁 **Auto Re-Sync** | Detects sensor resets & seamlessly re-enables all configured features. |
 | 🧮 **Float-Friendly API** | Returns handy structs (`Vector3`, `Quaternion`, `SensorEvent`) with SI units. |
 | 📚 **GPLv3 & Apache-2.0** | C++ wrapper under GPLv3; CEVA SH-2 backend under Apache 2.0 – both included. |
+| 🔌 **Pin Control API** | Optional helpers let you drive RSTN/BOOTN/WAKE and switch PS pins to select I²C, UART or SPI. |
 
 ---
 
@@ -71,13 +72,13 @@ src/
 Only the `BNO085.*` files and your chosen transport implementation are required
 for normal use. The other folders provide optional examples and helper code.
 
-Getting Started 🏁
+## Getting Started 🏁
 
 ```bash
-# Clone wherever you keep libs 📂
+#Clone wherever you keep libs 📂
 git clone --depth=1 https://github.com/yourOrg/bno085-cpp.git libs/bno085
 
-# Add the .cpp/.h files plus sh2/* to your project build.
+#Add the.cpp /.h files plus sh2/* to your project build.
 # CMake example ⤵️
 add_subdirectory(libs/bno085)
 target_link_libraries(myApp PRIVATE bno085)
@@ -222,6 +223,7 @@ walk‑through of the process.
 - **Accuracy**: `event.accuracy` (0–3) indicates calibration status. Wait for `3` before trusting the heading.
 - **DFU Mode**: hold **BOOTN** low during reset to enter the bootloader for firmware updates.
 - **Power Saving**: disable unused reports to save around 20 mA.
+- **Pin Helpers**: `hardwareReset()`, `setBootPin()`, `setWakePin()`, `selectInterface()` expose RSTN/BOOTN/WAKE and PS pins when wired.
 
 ## Contributing 🤝
 

--- a/src/BNO085.cpp
+++ b/src/BNO085.cpp
@@ -248,3 +248,49 @@ bool BNO085::configure(BNO085Sensor sensor, uint32_t intervalUs,
   }
   return true;
 }
+
+/** Toggle the hardware reset line if implemented. */
+void BNO085::hardwareReset(uint32_t lowMs) {
+  if (!io)
+    return;
+  io->setReset(false);
+  io->delay(lowMs);
+  io->setReset(true);
+  io->delay(50); // allow sensor to boot
+}
+
+/** Drive the BOOTN pin. */
+void BNO085::setBootPin(bool state) {
+  if (io)
+    io->setBoot(state);
+}
+
+/** Control the WAKE pin. */
+void BNO085::setWakePin(bool state) {
+  if (io)
+    io->setWake(state);
+}
+
+/** Select host interface using PS0/PS1. */
+void BNO085::selectInterface(BNO085Interface iface) {
+  if (!io)
+    return;
+  switch (iface) {
+  case BNO085Interface::I2C:
+    io->setPS1(false);
+    io->setPS0(false);
+    break;
+  case BNO085Interface::UARTRVC:
+    io->setPS1(true);
+    io->setPS0(false);
+    break;
+  case BNO085Interface::UART:
+    io->setPS1(false);
+    io->setPS0(true);
+    break;
+  case BNO085Interface::SPI:
+    io->setPS1(true);
+    io->setPS0(true);
+    break;
+  }
+}

--- a/src/BNO085.hpp
+++ b/src/BNO085.hpp
@@ -63,6 +63,16 @@ enum class BNO085Sensor : uint8_t {
   ARVRStabilizedGameRV = 0x29,       ///< Stabilized game rotation vector
   GyroIntegratedRV = 0x2A            ///< Gyro integrated rotation vector
 };
+/**
+ * @enum BNO085Interface
+ * @brief Host interface selection via PS pins.
+ */
+enum class BNO085Interface : uint8_t {
+  I2C,     ///< PS1=0, PS0=0
+  UARTRVC, ///< PS1=1, PS0=0
+  UART,    ///< PS1=0, PS0=1
+  SPI      ///< PS1=1, PS0=1
+};
 
 /**
  * @struct Vector3
@@ -159,6 +169,22 @@ public:
 
   /** Retrieve the last error code returned by the SH-2 driver. */
   int getLastError() const { return lastError; }
+
+  /**
+   * @brief Toggle the sensor's hardware reset line if available.
+   *
+   * Drives RSTN low for the specified time then releases it. Platforms not
+   * providing the pin may leave the implementation empty.
+   */
+  void hardwareReset(uint32_t lowMs = 2);
+
+  /** Set the BOOTN pin level (used to enter DFU). */
+  void setBootPin(bool state);
+  /** Control the WAKE pin in SPI mode. */
+  void setWakePin(bool state);
+
+  /** Select the host interface by driving PS pins. */
+  void selectInterface(BNO085Interface iface);
 
 private:
   /**

--- a/src/BNO085_Transport.hpp
+++ b/src/BNO085_Transport.hpp
@@ -63,4 +63,44 @@ public:
    * The transport implementation must provide this in microseconds.
    */
   virtual uint32_t getTimeUs() = 0;
+
+  /**
+   * @brief Control the hardware reset (RSTN) pin.
+   *
+   * The default implementation does nothing. Platforms that connect the
+   * sensor's RSTN pin can override this to assert or release reset.
+   */
+  virtual void setReset(bool state) {}
+
+  /**
+   * @brief Control the BOOTN pin used to enter DFU mode.
+   *
+   * Driving BOOTN low during a reset places the device in the bootloader.
+   * Implementations may leave this empty if the pin is not wired.
+   */
+  virtual void setBoot(bool state) {}
+
+  /**
+   * @brief Control the WAKE pin (SPI mode only).
+   *
+   * When using SPI, pulling WAKE low brings the device out of suspend. Not
+   * all designs expose this pin, so the default does nothing.
+   */
+  virtual void setWake(bool state) {}
+
+  /**
+   * @brief Drive protocol-select pin PS0.
+   *
+   * PS0 is sampled during reset to choose the active host interface. Some
+   * boards may expose this pin for dynamic control.
+   */
+  virtual void setPS0(bool state) {}
+
+  /**
+   * @brief Drive protocol-select pin PS1.
+   *
+   * Together with PS0 this determines whether I\xC2\xB2C, UART or SPI is used.
+   * Implementations may leave this empty if the pins are hard wired.
+   */
+  virtual void setPS1(bool state) {}
 };


### PR DESCRIPTION
## Summary
- refine README headings
- add BNO085Interface enum for PS pins
- expose selectInterface helper instead of raw PS pin setters
- document pin helpers

## Testing
- `clang-format -i src/BNO085.hpp src/BNO085.cpp src/BNO085_Transport.hpp README.md`
- `make test` *(fails: No rule to make target 'test'.)*

------
https://chatgpt.com/codex/tasks/task_e_6840d5c4d5048328a5051cf645c7d150