### PR TITLE
Add unified RVC wrapper and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,16 @@ Some Hillcrest/CEVA sensors offer a simplified "Robot Vacuum Cleaner" (RVC) mode
 that streams yaw/pitch/roll and linear acceleration over UART without any SH‑2
 commands.  If your application only needs basic orientation data and you want to
 avoid the overhead of the full protocol, this mode can be very handy.  The
-`src/rvc` folder contains a small decoder library and platform HAL examples.
+`src/rvc` folder contains a small decoder library, the `IRvcHal` interface and a
+lightweight `Rvc` C++ wrapper to tie everything together.
 
 Entering RVC mode is typically done via boot‑time pin strapping or a vendor
 command.  Once enabled the sensor continuously outputs 19‑byte frames at a fixed
 baud rate (usually 115200 bps).  Implement `IRvcHal` to read bytes from the
-serial port, register a callback, and call `rvc_service()` regularly to parse the
-incoming frames.  See [`src/rvc/README.md`](src/rvc/README.md) for full details
-and a code example.
+serial port, create a `Rvc` instance with your HAL, and register a callback.
+Calling `Rvc::service()` in your main loop will parse incoming frames.
+See [`src/rvc/README.md`](src/rvc/README.md) for full details and a complete
+example. A minimal program is provided in `examples/RVC_Basic.cpp`.
 
 ## Firmware Update (DFU) 📦
 

--- a/examples/RVC_Basic.cpp
+++ b/examples/RVC_Basic.cpp
@@ -1,0 +1,30 @@
+/**
+ * @file RVC_Basic.cpp
+ * @brief Minimal example showing how to read frames in RVC mode.
+ */
+
+#include "rvc/Rvc.hpp"
+#include "rvc/RvcHalEsp32C6.hpp" // Replace with your platform HAL
+#include <cstdio>
+
+static rvc_SensorValue_t g_val;
+
+static void onFrame(void *, rvc_SensorEvent_t *e) {
+    Rvc::decode(&g_val, e);
+    printf("Yaw %.2f Pitch %.2f Roll %.2f\n", g_val.yaw_deg, g_val.pitch_deg,
+           g_val.roll_deg);
+}
+
+int main() {
+    Esp32C6RvcHal hal; // Configure pins/port as needed
+    Rvc rvc(&hal);
+    rvc.setCallback(onFrame);
+    if (rvc.open() != RVC_OK)
+        return 1;
+
+    while (true) {
+        rvc.service();
+        // Add small delay if running on a busy system
+    }
+    return 0;
+}

--- a/src/rvc/README.md
+++ b/src/rvc/README.md
@@ -48,20 +48,24 @@ Use these to interpret how the sensor believes it is moving and any requested
 constraints from the host.
 
 ## Using the library
-1. Implement `IRvcHal` to read bytes from the UART connected to the sensor. An example for the ESP32‑C6 is provided in `RvcHalEsp32C6.hpp`.
-2. Call `rvc_init()` with your HAL instance and register a callback via `rvc_setCallback()`.
-3. After `rvc_open()` the library will parse incoming frames. Call `rvc_service()` regularly to process data.
+1. Implement `IRvcHal` to read bytes from the UART connected to the sensor. An
+   example for the ESP32‑C6 is provided in `RvcHalEsp32C6.hpp`.
+2. Create a `Rvc` object with your HAL and register a callback with
+   `Rvc::setCallback()`.
+3. Call `Rvc::open()` and then periodically `Rvc::service()` to decode frames.
 4. The UART runs 8N1 at 115200 bps on most devices. Adjust your HAL accordingly.
 
 ```c
 rvc_SensorValue_t val;
-void onFrame(void *cookie, rvc_SensorEvent_t *e) {
-    rvc_decode(&val, e);
+void onFrame(void *, rvc_SensorEvent_t *e) {
+    Rvc::decode(&val, e);
     printf("Yaw %.2f\n", val.yaw_deg);
 }
 ```
-See [`src/app/demo_rvc.c`](../app/demo_rvc.c) for a reference application that prints sensor values.
-The top-level [README](../../README.md) also contains a short overview of RVC mode.
+See [`examples/RVC_Basic.cpp`](../../examples/RVC_Basic.cpp) for a minimal
+application and [`src/app/demo_rvc.c`](../app/demo_rvc.c) for a more featureful
+reference.  The top-level [README](../../README.md) also contains a short
+overview of RVC mode.
 
 ## Entering RVC mode
 RVC mode is selected at boot time on the sensor. Consult the device data sheet for the exact pin settings or commands. Once the sensor is in RVC mode it continually streams the frame described above at a fixed rate (typically 115200 bps).

--- a/src/rvc/Rvc.hpp
+++ b/src/rvc/Rvc.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include "rvc.h"
+
+/**
+ * @brief Convenience C++ wrapper around the C RVC API.
+ *
+ * Construct with an IRvcHal implementation and then call open(), service(),
+ * and close() as needed. The class simply forwards to the underlying
+ * rvc_* functions.
+ */
+class Rvc {
+public:
+    /// Construct the wrapper and optionally initialize with a HAL.
+    explicit Rvc(IRvcHal *hal = nullptr) {
+        rvc_init(hal);
+    }
+
+    /// Change the HAL after construction.
+    void setHal(IRvcHal *hal) { rvc_init(hal); }
+
+    /// Register a callback for received frames.
+    int setCallback(rvc_Callback_t *cb, void *cookie = nullptr) {
+        return rvc_setCallback(cb, cookie);
+    }
+
+    /// Begin reading frames using the HAL.
+    int open() { return rvc_open(); }
+
+    /// Stop reading frames.
+    void close() { rvc_close(); }
+
+    /// Poll the UART and dispatch any available frames.
+    void service() { rvc_service(); }
+
+    /// Helper to decode a raw event to floating point values.
+    static void decode(rvc_SensorValue_t *val, const rvc_SensorEvent_t *ev) {
+        rvc_decode(val, ev);
+    }
+};


### PR DESCRIPTION
## Summary
- provide a small `Rvc` C++ wrapper around the existing RVC C API
- add a basic RVC example using the wrapper
- document the wrapper in the top level README
- update `src/rvc/README.md` with new usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840dfdc9b6c83289efde80bc6314ce5