### PR TITLE
Integrate RVC helper into BNO085

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,15 @@ that streams yaw/pitch/roll and linear acceleration over UART without any SH‑2
 commands.  If your application only needs basic orientation data and you want to
 avoid the overhead of the full protocol, this mode can be very handy.  The
 `src/rvc` folder contains a small decoder library, the `IRvcHal` interface and a
-lightweight `Rvc` C++ wrapper to tie everything together.
+lightweight `Rvc` C++ wrapper.  The high level `BNO085` class also exposes helper
+methods so you can handle RVC data without using the separate wrapper.
 
 Entering RVC mode is typically done via boot‑time pin strapping or a vendor
 command.  Once enabled the sensor continuously outputs 19‑byte frames at a fixed
 baud rate (usually 115200 bps).  Implement `IRvcHal` to read bytes from the
-serial port, create a `Rvc` instance with your HAL, and register a callback.
-Calling `Rvc::service()` in your main loop will parse incoming frames.
+serial port and either create a dedicated `Rvc` instance or call `beginRvc()` on
+`BNO085`.  Register a callback with `setRvcCallback()` and call `serviceRvc()` in
+your loop to parse incoming frames.
 See [`src/rvc/README.md`](src/rvc/README.md) for full details and a complete
 example. A minimal program is provided in `examples/RVC_Basic.cpp`.
 

--- a/examples/RVC_Basic.cpp
+++ b/examples/RVC_Basic.cpp
@@ -3,27 +3,24 @@
  * @brief Minimal example showing how to read frames in RVC mode.
  */
 
-#include "rvc/Rvc.hpp"
+#include "BNO085.hpp"
 #include "rvc/RvcHalEsp32C6.hpp" // Replace with your platform HAL
 #include <cstdio>
 
-static rvc_SensorValue_t g_val;
-
-static void onFrame(void *, rvc_SensorEvent_t *e) {
-    Rvc::decode(&g_val, e);
-    printf("Yaw %.2f Pitch %.2f Roll %.2f\n", g_val.yaw_deg, g_val.pitch_deg,
-           g_val.roll_deg);
+static void onFrame(const rvc_SensorValue_t &v) {
+    printf("Yaw %.2f Pitch %.2f Roll %.2f\n", v.yaw_deg, v.pitch_deg,
+           v.roll_deg);
 }
 
 int main() {
     Esp32C6RvcHal hal; // Configure pins/port as needed
-    Rvc rvc(&hal);
-    rvc.setCallback(onFrame);
-    if (rvc.open() != RVC_OK)
+    BNO085 imu;
+    imu.setRvcCallback(onFrame);
+    if (!imu.beginRvc(&hal))
         return 1;
 
     while (true) {
-        rvc.service();
+        imu.serviceRvc();
         // Add small delay if running on a busy system
     }
     return 0;


### PR DESCRIPTION
## Summary
- integrate RVC helper library with the BNO085 class
- expose beginRvc/serviceRvc/setRvcCallback API
- update RVC example to use the new helper
- document unified RVC handling in README

## Testing
- `make -n` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3d28c908328a9023c2a5919ea69