### PR TITLE
Add documentation index and cross links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Hardware-agnostic BNO08x library as used in the HardFOC‑V1 controller.
 
+Looking for all of the documentation in one place? Check out the
+[documentation index](docs/index.md) which links to every guide and
+tutorial in this repository.
+
 ## BNO085 C++ Sensor Library 🚀
 
 > **Full-stack, hardware-agnostic, zero-thread driver for Hillcrest / CEVA BNO08x**  
@@ -255,5 +259,7 @@ By contributing you agree your code is released under the same GPLv3 license.
 - CEVA Inc. for open-sourcing the SH-2 driver.
 - SparkFun & Adafruit for inspiring wiring diagrams.
 - Everyone in the open-source IMU community 💖
+
+For more guides see the [documentation index](docs/index.md).
 
 Made with a cup of ☕ and a dash of 🚀

--- a/docs/BNO085_Complete_Guide.md
+++ b/docs/BNO085_Complete_Guide.md
@@ -2,6 +2,10 @@
 
 This document compiles information from the official BNO080/085 datasheet and expands on the existing README. It explains how the sensor works, covers wiring, available modes, and shows example code for both **Arduino** and **ESP32** platforms.
 
+For a quick start see the [main README](../README.md). Additional topics are
+covered in the [RVC mode guide](../src/rvc/README.md) and the
+[DFU framework guide](../src/dfu/README.md).
+
 ## Overview
 
 The **BNO085** is a 9‑axis absolute orientation sensor from Hillcrest Labs/CEVA. It combines a 3‑axis gyroscope, 3‑axis accelerometer and 3‑axis magnetometer with an onboard 32‑bit microcontroller running the **SH‑2** sensor fusion software. The IMU outputs a wide range of sensor data and high level events without requiring heavy computation on the host.
@@ -257,4 +261,7 @@ This example prints the yaw angle at 100 Hz on an Arduino‑compatible board.
 
 ---
 
-For more information consult the official datasheet and the examples provided with this repository.
+For more information consult the official datasheet and the examples provided
+with this repository. You can also explore firmware updates in the
+[DFU framework guide](../src/dfu/README.md) or learn about the simplified
+[RVC mode](../src/rvc/README.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# HF-BNO08x Documentation
+
+Welcome to the HF-BNO08x library documentation. This page collects the main guides and tutorials available in the repository.
+
+## Guides
+
+- [Getting Started](../README.md) – quick start instructions and library overview.
+- [BNO085 Complete Guide](BNO085_Complete_Guide.md) – in depth details on the sensor and library usage.
+- [RVC Mode Guide](../src/rvc/README.md) – explains the lightweight Robot Vacuum Cleaner UART protocol.
+- [DFU Framework Guide](../src/dfu/README.md) – how to update sensor firmware using the provided DFU helpers.
+
+The PDF data sheet is also available in the [datasheet folder](../datasheet/BNO080_085-Datasheet.pdf).

--- a/src/dfu/README.md
+++ b/src/dfu/README.md
@@ -5,6 +5,10 @@ update (DFU) routines.  Hardware access is abstracted through the
 `IDfuTransport` C++ interface.  Applications must supply an implementation
 of this interface for their platform and pass it to `dfu()`.
 
+If you are new to the sensor start with the
+[BNO085 Complete Guide](../../docs/BNO085_Complete_Guide.md). RVC mode
+is covered separately in the [RVC guide](../rvc/README.md).
+
 `HalTransport` is provided as an adapter for the vendor supplied
 `sh2_Hal_t` structures so existing C HAL implementations can be used
 without modification.
@@ -44,3 +48,4 @@ links. See the source files for details if you need to adjust the timeout.
 This directory only contains minimal stub firmware images. Consult the sensor
 vendor for production firmware files. The [top-level README](../../README.md)
 also summarises DFU usage in the context of the full library.
+Additional guides are listed in the [documentation index](../../docs/index.md).

--- a/src/rvc/README.md
+++ b/src/rvc/README.md
@@ -2,6 +2,8 @@
 
 This folder contains a small helper library for **RVC mode** on BNO08x / FSP200 series sensors. RVC ("Robot Vacuum Cleaner") mode is a simplified UART protocol that streams orientation and motion data as fixed frames instead of using the SH-2 command interface.
 
+For a full overview of the sensor see the [BNO085 Complete Guide](../../docs/BNO085_Complete_Guide.md). Firmware update instructions are available in the [DFU framework guide](../dfu/README.md).
+
 ## Why use RVC mode?
 - No command parsing or feature configuration is required. The sensor outputs data continuously once powered.
 - Useful for resource constrained systems that only need yaw/pitch/roll and linear acceleration.
@@ -69,6 +71,8 @@ overview of RVC mode.
 
 ## Entering RVC mode
 RVC mode is selected at boot time on the sensor. Consult the device data sheet for the exact pin settings or commands. Once the sensor is in RVC mode it continually streams the frame described above at a fixed rate (typically 115200 bps).
+
+See the [documentation index](../../docs/index.md) for links to all guides.
 
 ---
 Released under the Apache 2.0 license (see [LICENSE](../../LICENSE)).


### PR DESCRIPTION
## Summary
- add docs index page for GitHub Pages
- link README to the new index
- cross-link documentation between the main guide, RVC mode and DFU guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684250ca61e08328b74d0489e17c7a6e