### PR TITLE
Fix incomplete sh2 type

### DIFF
--- a/src/BNO085.hpp
+++ b/src/BNO085.hpp
@@ -18,10 +18,8 @@
 #include <functional>
 
 extern "C" {
-struct sh2_SensorValue_t;
-struct sh2_SensorEvent_t;
-struct sh2_AsyncEvent_t;
-struct sh2_Hal_t;
+#include "sh2/sh2.h"
+#include "sh2/sh2_SensorValue.h"
 }
 
 /**

--- a/src/dfu/IDfuTransport.hpp
+++ b/src/dfu/IDfuTransport.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 
 extern "C" {
-struct sh2_Hal_t;
+#include "sh2/sh2_hal.h"
 }
 
 /**


### PR DESCRIPTION
## Summary
- include vendor headers so sh2 types are fully defined
- include sh2 HAL header in DFU transport interface